### PR TITLE
Quad.php: Subject must be of type NamedNode or BlankNode

### DIFF
--- a/src/rdfInterface/Quad.php
+++ b/src/rdfInterface/Quad.php
@@ -47,7 +47,7 @@ interface Quad extends Term
      * @param NamedNode|BlankNode|null $graphIri
      */
     public function __construct(
-        Term $subject,
+        NamedNode | BlankNode $subject,
         NamedNode $predicate,
         Term $object,
         NamedNode | BlankNode | null $graphIri = null


### PR DESCRIPTION
Other types of `Term` as subject are not allowed in quads, ref RDF 1.1: https://www.w3.org/TR/rdf11-concepts/#section-triples