### PR TITLE
Literal.php: in constructor set ?string for $datatype

### DIFF
--- a/src/rdfInterface/Literal.php
+++ b/src/rdfInterface/Literal.php
@@ -39,7 +39,7 @@ interface Literal extends Term
     public function __construct(
         int | float | string | bool | Stringable $value,
         ?string $lang = null,
-        string $datatype = RDF::XSD_STRING
+        ?string $datatype = RDF::XSD_STRING
     );
 
     public function getValue(): int | float | string | bool | Stringable;


### PR DESCRIPTION
I believe you missed an `?` there, because lang and datatype can be null. If that is not the case, the following file in quickRdf should be adapted: https://github.com/sweetrdf/quickRdf/blob/master/src/quickRdf/Literal.php#L62