### PR TITLE
TermsTest.php: if literal has lang set, it has to return rdf:langString as datatype

### DIFF
--- a/tests/TermsTest.php
+++ b/tests/TermsTest.php
@@ -122,7 +122,8 @@ abstract class TermsTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($l[0]->equals($l[5]));
 
         $this->assertEquals('eng', $l[1]->getLang());
-        $this->assertEquals(RDF::XSD_STRING, $l[1]->getDatatype());
+        // FYI: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+        $this->assertEquals('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', $l[1]->getDatatype());
         $this->assertFalse($l[1]->equals($l[2]));
         $this->assertFalse($l[1]->equals($l[3]));
         $this->assertFalse($l[1]->equals($l[4]));


### PR DESCRIPTION
A test is not in line with https://github.com/sweetrdf/rdfInterface/issues/12#issuecomment-802059207:

```php
$l[1] = self::$df::literal('1', 'eng');
```
The test expects `$l[1]->getDatatype()` to return `xsd:string`

```php
$this->assertEquals(RDF::XSD_STRING, $l[1]->getDatatype());
```

but has to expect `rdf:langString`:

```php
$this->assertEquals('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString', $l[1]->getDatatype());
```

Based on:

> A literal in an RDF graph consists of two or three elements:
> [...]
>   if and only if the datatype IRI is http://www.w3.org/1999/02/22-rdf-syntax-ns#langString, a non-empty language tag as defined by [BCP47]. The language tag must be well-formed according to section 2.2.9 of [BCP47].

Source: https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal