### PR TITLE
feat: allow psr/http-message 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=8.0",
         "zozlak/rdf-constants": "*",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
No other change is necessary as the types are only used in docblocks.