### PR TITLE
DatasetNodeInterface: fixed getPredicate parameter and return value types

### DIFF
--- a/src/rdfInterface/DatasetInterface.php
+++ b/src/rdfInterface/DatasetInterface.php
@@ -415,9 +415,9 @@ interface DatasetInterface extends QuadIteratorAggregateInterface, \ArrayAccess,
      * Fetches subject of a first quad matching a given filter or null if no quad matches the filter.
      * 
      * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|null $filter
-     * @return TermInterface | null
+     * @return NamedNodeInterface | null
      */
-    public function getPredicate(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): TermInterface | null;
+    public function getPredicate(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): NamedNodeInterface | null;
 
     /**
      * Fetches object of a first quad matching a given filter or null if no quad matches the filter.

--- a/src/rdfInterface/DatasetNodeInterface.php
+++ b/src/rdfInterface/DatasetNodeInterface.php
@@ -535,8 +535,8 @@ interface DatasetNodeInterface extends TermInterface, DatasetInterface {
     public function listGraphs(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): TermIteratorInterface;
 
     /**
-     * Fetches subject of a first quad having subject matching dataset
-     * node's node and a given filter or null otherwise.
+     * Fetches subject of a first quad matching a given filter and subject
+     * matching dataset node's node or null otherwise.
      * 
      * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|null $filter
      * @return TermInterface | null
@@ -544,16 +544,16 @@ interface DatasetNodeInterface extends TermInterface, DatasetInterface {
     public function getSubject(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): TermInterface | null;
 
     /**
-     * Fetches predicate of a first quad having predicate matching dataset
-     * node's node and a given filter or null otherwise.
+     * Fetches predicate of a first quad matching a given filter and subject
+     * matching dataset node's node or null otherwise.
      * 
      * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|null $filter
      */
     public function getPredicate(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): NamedNodeInterface | null;
 
     /**
-     * Fetches object of a first quad  having subject matching dataset
-     * node's node and a given filter or null otherwise.
+     * Fetches object of a first quad mathing a given filter and subject
+     * matching dataset node's node or null otherwise.
      * 
      * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|null $filter
      * @return TermInterface | null
@@ -561,8 +561,8 @@ interface DatasetNodeInterface extends TermInterface, DatasetInterface {
     public function getObject(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): TermInterface | null;
 
     /**
-     * Fetches graph of a first quad  having subject matching dataset
-     * node's node and a given filter or null otherwise.
+     * Fetches graph of a first quad matching a given filter and subject
+     * matching dataset node's node or null otherwise.
      * 
      * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|null $filter
      * @return TermInterface | null

--- a/src/rdfInterface/DatasetNodeInterface.php
+++ b/src/rdfInterface/DatasetNodeInterface.php
@@ -544,13 +544,12 @@ interface DatasetNodeInterface extends TermInterface, DatasetInterface {
     public function getSubject(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): TermInterface | null;
 
     /**
-     * Fetches subject of a first quad having subject matching dataset
+     * Fetches predicate of a first quad having predicate matching dataset
      * node's node and a given filter or null otherwise.
      * 
      * @param QuadCompareInterface|QuadIteratorInterface|QuadIteratorAggregateInterface|callable|null $filter
-     * @return TermInterface | null
      */
-    public function getPredicate(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): TermInterface | null;
+    public function getPredicate(QuadCompareInterface | QuadIteratorInterface | QuadIteratorAggregateInterface | callable | null $filter = null): NamedNodeInterface | null;
 
     /**
      * Fetches object of a first quad  having subject matching dataset


### PR DESCRIPTION
I am experiencing type-related issues in some of our rdfInterface-based libraries and found this example. Based on feedback from PHPStan and what I've read in the code/documentation, the function `getPredicate`  shall return null or an instance of `NamedNodeInterface`.